### PR TITLE
Fix last author always being registered as unknown

### DIFF
--- a/rofi-zotero.py
+++ b/rofi-zotero.py
@@ -19,6 +19,7 @@ import sqlite3
 import subprocess
 import sys
 import tempfile
+from collections import defaultdict
 from pathlib import Path
 
 __version__ = "0.1"
@@ -555,17 +556,13 @@ def main(
 
     os.remove(database_copy)
 
-    authors = {}
-    author_list = []
-    if len(all_authors) > 0:
-        id = all_authors[0][0]
-        for author_id, author in all_authors:
-            if author_id != id:
-                authors[id] = format_authors(author_list)
-                author_list = []
-                id = author_id
+    author_lists = defaultdict(lambda: [])
+    for author_id, author in all_authors:
+        author_lists[author_id].append(author)
 
-            author_list.append(author)
+    authors = {
+        id: format_authors(author_list) for id, author_list in author_lists.items()
+    }
 
     titles = {}
     keys = {}


### PR DESCRIPTION
Hello! I love the script, but I stumbled upon incorrect registration of authors for one of my zotero items (the last one).

The author_list aggregation will format a list of authors once it detects that the `id` of the author changes compared to the `id` of the item. For the last author this never triggers, resulting in the author not getting registered into the `authors` dict.

The end result is the paper with the most recently added author being counted as `Unknown`.

This patch changes the aggregation to use a `defaultdict` instead, which simplifies the code a bit but more importantly removes the bug.